### PR TITLE
Improve keyboard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,22 @@ These flags can be used simultaneously. For example:
 
     python interpreter.py -m 2048 -sm example.hex  
     python interpreter.py -av example.asm
+
+
+Keyboard
+--------
+
+The interpreter's standard behaviour of reading keyboard input from address `[-512]` is done by reading inputs from
+`stdin`. However, this input does not register until the user has pressed the Enter key, which generally makes it hard
+to read real-time input from the keyboard.
+
+The interpreter also supports real-time user input, if the python module `getkey` is installed:
+
+    pip install getkey
+
+In this advanced behaviour, the interpreter keeps track of a buffer of keyboard inputs. Whenever we read from address
+`[-512]` using assembly, the first value of this buffer is returned and removed from the buffer. If the buffer is empty,
+the value 0 will be returned.
+
+If the `getkey` module is installed, the interpreter will automatically use this advanced method of reading keyboard
+input.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,19 @@ There are multiple flags that can be used to execute this program:
 
 
     -sr, --show-registers:
-       python interpreter.py -sr filename
+      python interpreter.py -sr filename
+        or
+      python interpreter.py --show-registers filename
 
     After execution of the machinecode, the registers are displayed.
+
+    -k, --keyboard:
+      python interpreter.py -k filename
+        or
+      python interpreter.py --keyboard filename
+
+    Enables advanced keyboard behaviour, in which keystrokes are read to an internal buffer
+    instead of reading from stdin. See also the Keyboard section below.
 
 These flags can be used simultaneously. For example:
 
@@ -97,5 +107,5 @@ In this advanced behaviour, the interpreter keeps track of a buffer of keyboard 
 `[-512]` using assembly, the first value of this buffer is returned and removed from the buffer. If the buffer is empty,
 the value 0 will be returned.
 
-If the `getkey` module is installed, the interpreter will automatically use this advanced method of reading keyboard
-input.
+This advanced keyboard behaviour will be enabled if the `getkey` module is installed, and the `--keyboard` flag is
+passed.

--- a/instructions.py
+++ b/instructions.py
@@ -1,6 +1,3 @@
-import sys
-
-
 class Instruction(object):
 
     def __init__(self, condition):
@@ -52,10 +49,7 @@ class Read(Instruction):
     def execute(self, pc):
         address = pc.get_reg(self.reg_a) + self.offset
 
-        if address == -512:
-            data = ord(sys.stdin.read(1))
-        else:
-            data = pc.read_memory(address)
+        data = pc.read_memory(address)
         pc.set_reg(self.reg_d, data)
 
 
@@ -82,13 +76,7 @@ class Write(Instruction):
         address = pc.get_reg(self.reg_a) + self.offset
         data = pc.get_reg(self.reg_b)
 
-        if address == -512:
-            if pc.is_verbose():
-                print('\n[!] Output: {}\n'.format(chr(data)))
-            else:
-                sys.stdout.write(chr(data))
-        else:
-            pc.write_memory(address, data)
+        pc.write_memory(address, data)
 
 
 class Push(Instruction):

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,5 +1,5 @@
 from instructions import *
-from keyboard import get_keyboard
+from keyboard import *
 import argparse
 import os
 import subprocess
@@ -7,9 +7,8 @@ import sys
 
 
 class Computer:
-    def __init__(self, mem_size, verbose):
-        self.keyboard = get_keyboard()
-
+    def __init__(self, keyboard, mem_size, verbose):
+        self.keyboard = keyboard
         self.registers = [0 for _ in range(16)]
         self.set_reg(14, mem_size * 4)
         self.memory = [0 for _ in range(mem_size * 4)]
@@ -176,6 +175,8 @@ parser.add_argument('-sr', '--show-registers', action='store_true',
                     help='Print the registers after execution')
 parser.add_argument('-a', '--assemble', action='store_true',
                     help='Assemble the inputfile first (requires assembler)')
+parser.add_argument('-k', '--keyboard', action='store_true',
+                    help='Use advanced keyboard input (requires `getkey`)')
 
 args = parser.parse_args()
 
@@ -203,7 +204,18 @@ if args.assemble:
 else:
     filename = args.filename
 
-cmp = Computer(args.memory, args.verbose)
+if args.keyboard and KEYBOARD_ENABLED:
+    keyboard = Keyboard()
+    keyboard.start()
+elif args.keyboard:
+    print('[!] Advanced keyboard behaviour not supported!')
+    print('[!] Falling back to default input...')
+    keyboard = BaseKeyboard()
+else:
+    keyboard = BaseKeyboard()
+
+
+cmp = Computer(keyboard, args.memory, args.verbose)
 cmp.read_memory_file(filename)
 
 try:

--- a/keyboard.py
+++ b/keyboard.py
@@ -7,13 +7,7 @@ except ImportError:
     getkey = None
 
 
-def get_keyboard():
-    if getkey is None:
-        return BaseKeyboard()
-
-    keyboard = Keyboard()
-    keyboard.start()
-    return keyboard
+KEYBOARD_ENABLED = getkey is not None
 
 
 class BaseKeyboard:

--- a/keyboard.py
+++ b/keyboard.py
@@ -1,0 +1,43 @@
+import sys
+import threading
+
+try:
+    from getkey import getkey
+except ImportError:
+    getkey = None
+
+
+def get_keyboard():
+    if getkey is None:
+        return BaseKeyboard()
+
+    keyboard = Keyboard()
+    keyboard.start()
+    return keyboard
+
+
+class BaseKeyboard:
+    def read_character(self):
+        return ord(sys.stdin.read(1))
+
+
+class Keyboard(BaseKeyboard, threading.Thread):
+    def __init__(self):
+        threading.Thread.__init__(self)
+
+        self.buffer = []
+        self.daemon = True
+
+    def read_character(self):
+        if self.buffer:
+            return self.buffer.pop(0)
+        return 0
+
+    def run(self):
+        while True:
+            char = getkey()
+
+            try:
+                self.buffer.append(ord(char))
+            except TypeError:
+                pass


### PR DESCRIPTION
The interpreter now supports real-time keyboard input.

Initially, the interpreter was only able to read input from `stdin`, but this input only registered after pressing enter. The new method saves key presses in a buffer, which can be read by reading from `[-512]` as usual. If the buffer is empty, the value 0 will be read. This behaviour mimics the behaviour used currently in Digital, and previously in Hades (if I'm not mistaken).

Usage of this advanced behaviour requires the [`getkey`](https://github.com/kcsaff/getkey) library. If this library is installed, the input behaviour will change automatically.